### PR TITLE
SENTRY-1836 Add sentry web service config in service template

### DIFF
--- a/conf/sentry-site.xml.service.template
+++ b/conf/sentry-site.xml.service.template
@@ -123,4 +123,16 @@
     <description>Service Kerberos principal</description>
   </property>
 
+  <property>
+    <name>sentry.service.web.enable</name>
+    <value>false</value>
+    <description>Enable web service</description>
+  </property>
+
+  <property>
+    <name>sentry.service.web.authentication.type</name>
+    <value>NONE</value>
+    <description>Options: kerberos, NONE.  Authentication mode for Sentry web service.</description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/SENTRY-1836](https://issues.apache.org/jira/browse/SENTRY-1836)
Sentry has web service which is closed by default. If the user wants to enable this feature, but do not know how to configure. In order to facilitate the user to enable this feature relevant configuration items must be added in the template.