### PR TITLE
fixed log message for privilege revocation

### DIFF
--- a/sentry-provider/sentry-provider-db/src/main/java/org/apache/sentry/provider/db/generic/UpdatableCache.java
+++ b/sentry-provider/sentry-provider-db/src/main/java/org/apache/sentry/provider/db/generic/UpdatableCache.java
@@ -178,12 +178,12 @@ public final class UpdatableCache implements TableCache, AutoCloseable {
 
   private void revokeAllPrivilegesIfRequired() {
     if (++consecutiveUpdateFailuresCount > allowedUpdateFailuresCount) {
-      consecutiveUpdateFailuresCount = 0;
       // Clear cache to revoke all privileges.
       // Update table cache to point to an empty table to avoid thread-unsafe characteristics of HashBasedTable.
       this.table = HashBasedTable.create();
       LOGGER.error("Failed to update roles and privileges cache for " + consecutiveUpdateFailuresCount + " times." +
           " Revoking all privileges from cache, which will cause all authorization requests to fail.");
+      consecutiveUpdateFailuresCount = 0;
     }
   }
 


### PR DESCRIPTION
When `revokeAllPrivilegesIfRequired` gets called, the variable `consecutiveUpdateFailuresCount` does get set to `0` before the log message is written.

This causes the logs to always show that the cache update failed for 0 times:

```
RROR org.apache.sentry.provider.db.generic.UpdatableCache: Failed to update roles and privileges cache for 0 times. Revoking all privileges from cache, which will cause all authorization requests to fail.
```